### PR TITLE
Fix CSS multiple selectors rules

### DIFF
--- a/live-coding.js
+++ b/live-coding.js
@@ -42,9 +42,9 @@ var LiveCoding = (function() {
 			cssRules = cssRules.replace(/^\s+/g,'').replace(/\s+$/g,'');
 			var reg = /(\{|\})/g;
 			cssRules = cssRules.split(reg);
-			for(var i = 0; i < cssRules.length - 1; i+=4){
+			for (var i = 0; i < cssRules.length - 1; i+=4) {
 				var selectors = cssRules[i].split(',');
-				for(var j = 0; j < selectors.length; j++){
+				for (var j = 0; j < selectors.length; j++) {
 					selectors[j] = '#' + demoElementId + ' ' + selectors[j];
 				}
 				cssRules[i] = selectors.join(',');
@@ -53,7 +53,7 @@ var LiveCoding = (function() {
 
 			// if <style id="liveCoding_9999"> doesn't exist, create it
 			var styleElement = document.getElementById('liveCoding_' + demoElementId);
-			if( styleElement === null ){
+			if (styleElement === null) {
 				styleElement = document.createElement('style');
 				styleElement.setAttribute('id','liveCoding_' + demoElementId);
 				insertAfter(demoElement, styleElement);
@@ -61,7 +61,7 @@ var LiveCoding = (function() {
 			styleElement.innerHTML = cssRules;
 
 		// else, if it's markup (HTML, SVG, XML...)
-		} else if(isMarkup) {
+		} else if (isMarkup) {
 			// replace content 
 			demoElement.innerHTML = codeElement.innerHTML;
 		}


### PR DESCRIPTION
Hi!

I fixed a bug: when a CSS rules are multiple selector, only the first one was prefixed with the demonstration element id.

I took the opportunity to renamed variables:
- allCode => codeElementList
- code => codeElement
- val => cssRules
- style => styleElement
  
  I also tried to improve syntax consistency:
- space before brackets
- space after statement

Cheers,
Thomas.
